### PR TITLE
DALAMUD_RUNTIME 환경변수 설정

### DIFF
--- a/Dalamud.Updater/FormMain.cs
+++ b/Dalamud.Updater/FormMain.cs
@@ -694,12 +694,9 @@ namespace Dalamud.Updater
             //return false;
             var dalamudStartInfo = GeneratingDalamudStartInfo(process, Directory.GetParent(dalamudUpdater.Runner.FullName).FullName, injectDelay);
             var environment = new Dictionary<string, string>();
-            // No use cuz we're injecting instead of launching, the Dalamud.Boot.dll is reading environment variables from ffxiv_dx11.exe
-            /*
             var prevDalamudRuntime = Environment.GetEnvironmentVariable("DALAMUD_RUNTIME");
             if (string.IsNullOrWhiteSpace(prevDalamudRuntime))
                 environment.Add("DALAMUD_RUNTIME", runtimeDirectory.FullName);
-            */
             WindowsDalamudRunner.Inject(dalamudUpdater.Runner, process.Id, environment, DalamudLoadMethod.DllInject, dalamudStartInfo);
             return true;
         }


### PR DESCRIPTION
해당 부분이 주석된 이유는 추측하기로는
주석이 된 시점 부터 중국판 XIVLauncher이 런칭되었고, 이때문에 runtime 설정이 추가로 필요 없어진것처럼 보입니다.

하지만 한국 버전에서는 XIVLauncher 으로 실행하지 않기 때문에
별도로 추가 설치해야되는 번거로움을 없애기 위해서 runtime을 설정하도록 다시 활성화 하는 것이 좋아보입니다.